### PR TITLE
Feat(cms)/schema tweak for builders page

### DIFF
--- a/cms-backend/src/api/for-builders-page-use-cases-section/content-types/for-builders-page-use-cases-section/schema.json
+++ b/cms-backend/src/api/for-builders-page-use-cases-section/content-types/for-builders-page-use-cases-section/schema.json
@@ -12,6 +12,9 @@
   },
   "pluginOptions": {},
   "attributes": {
+    "sectionHeader": {
+      "type": "string"
+    },
     "useCases": {
       "type": "relation",
       "relation": "oneToMany",

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -660,6 +660,7 @@ export interface ApiForBuildersPageUseCasesSectionForBuildersPageUseCasesSection
     draftAndPublish: true;
   };
   attributes: {
+    sectionHeader: Schema.Attribute.String;
     useCases: Schema.Attribute.Relation<'oneToMany', 'api::use-case.use-case'>;
     useCaseTitle: Schema.Attribute.String;
     useCaseDescription: Schema.Attribute.String;

--- a/frontend/src/components/ForBuilders/Hero.tsx
+++ b/frontend/src/components/ForBuilders/Hero.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import LinkArrow from "@/assets/svgs/icons/link-arrow.svg";
+import Button from "@/components/Button";
+import { HeroQueryType } from "@/queries/for-builders/hero";
+
+interface IHero {
+  heroData: HeroQueryType["forBuildersPageHero"];
+}
+
+const Hero: React.FC<IHero> = ({ heroData }) => {
+  return (
+    <div className="relative h-[835px] pt-44 pb-28 px-6">
+      <div className="space-y-6">
+        <h1 className="text-3xl w-min">{heroData.title}</h1>
+        <p className="text-lg">{heroData.subtitle}</p>
+        <div>
+          <Link
+            href={heroData.button.link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button>
+              <span className="text-background-2">{heroData.button.text}</span>
+            </Button>
+          </Link>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          {heroData.arrowLink.map((arrowLink) => (
+            <Link
+              key={arrowLink.text}
+              href={arrowLink.link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="mr-4">{arrowLink.text}</span>
+              <Image
+                src={LinkArrow}
+                width="24"
+                height="24"
+                alt="Arrow link image"
+                className="inline"
+              />
+            </Link>
+          ))}
+        </div>
+      </div>
+      <Image
+        src={heroData.background.url}
+        alt="Hero Image Background"
+        width="1440"
+        height="835"
+        className="absolute top-0 h-full object-cover object-left left-0 z-[-1]"
+      />
+    </div>
+  );
+};
+
+export default Hero;

--- a/frontend/src/components/ForBuilders/Hero.tsx
+++ b/frontend/src/components/ForBuilders/Hero.tsx
@@ -23,8 +23,8 @@ const Hero: React.FC<IHero> = ({ heroData }) => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Button>
-              <span className="text-background-2">{heroData.button.text}</span>
+            <Button variant="secondary">
+              <span>{heroData.button.text}</span>
             </Button>
           </Link>
         </div>

--- a/frontend/src/pages/for-builders.tsx
+++ b/frontend/src/pages/for-builders.tsx
@@ -1,0 +1,43 @@
+import Footer from "@/components/Footer";
+import Hero from "@/components/ForBuilders/Hero";
+import Navbar from "@/components/Navbar";
+import { footerQuery, FooterQueryType } from "@/queries/footer";
+import { navbarQuery, NavbarQueryType } from "@/queries/navbar";
+import { heroQuery, HeroQueryType } from "@/queries/for-builders/hero";
+import { graphQLClient } from "@/utils/graphQLClient";
+
+interface IForBuilders {
+  navbarData: NavbarQueryType;
+  footerData: FooterQueryType;
+  heroData: HeroQueryType["forBuildersPageHero"];
+}
+
+const ForBuilders: React.FC<IForBuilders> = ({
+  footerData,
+  heroData,
+  navbarData,
+}) => {
+  return (
+    <div>
+      <Navbar {...{ navbarData }} />
+      <Hero {...{ heroData }} />
+      <Footer {...{ footerData }} />
+    </div>
+  );
+};
+
+export const getStaticProps = async () => {
+  const navbarData = await graphQLClient.request<NavbarQueryType>(navbarQuery);
+  const footerData = await graphQLClient.request<FooterQueryType>(footerQuery);
+  const heroData = await graphQLClient.request<HeroQueryType>(heroQuery);
+
+  return {
+    props: {
+      navbarData,
+      footerData,
+      heroData: heroData.forBuildersPageHero,
+    },
+  };
+};
+
+export default ForBuilders;

--- a/frontend/src/queries/for-builders/hero.tsx
+++ b/frontend/src/queries/for-builders/hero.tsx
@@ -1,0 +1,47 @@
+import { gql } from "graphql-request";
+
+export const heroQuery = gql`
+  {
+    forBuildersPageHero {
+      title
+      subtitle
+      button {
+        text
+        link {
+          url
+        }
+      }
+      arrowLink {
+        text
+        link {
+          url
+        }
+      }
+      background {
+        url
+      }
+    }
+  }
+`;
+
+export type HeroQueryType = {
+  forBuildersPageHero: {
+    title: string;
+    subtitle: string;
+    button: {
+      text: string;
+      link: {
+        url: string;
+      };
+    };
+    arrowLink: {
+      text: string;
+      link: {
+        url: string;
+      };
+    }[];
+    background: {
+      url: string;
+    };
+  };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `Hero` component for the builders page, featuring a title, subtitle, and a button with external link functionality.
	- Added a `ForBuilders` page layout integrating the `Hero`, `Navbar`, and `Footer` components.
	- Implemented a new GraphQL query to fetch data for the hero section, enhancing data retrieval and display.

- **Enhancements**
	- Added a `sectionHeader` attribute to the JSON schema for improved content management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->