### PR TITLE
feat(cms): pnk-token-page-types

### DIFF
--- a/cms-backend/src/api/exchange/content-types/exchange/schema.json
+++ b/cms-backend/src/api/exchange/content-types/exchange/schema.json
@@ -1,0 +1,28 @@
+{
+  "kind": "collectionType",
+  "collectionName": "exchanges",
+  "info": {
+    "singularName": "exchange",
+    "pluralName": "exchanges",
+    "displayName": "Exchange"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "url": {
+      "type": "string"
+    },
+    "icon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/src/api/exchange/controllers/exchange.ts
+++ b/cms-backend/src/api/exchange/controllers/exchange.ts
@@ -1,0 +1,7 @@
+/**
+ * exchange controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::exchange.exchange');

--- a/cms-backend/src/api/exchange/routes/exchange.ts
+++ b/cms-backend/src/api/exchange/routes/exchange.ts
@@ -1,0 +1,7 @@
+/**
+ * exchange router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::exchange.exchange');

--- a/cms-backend/src/api/exchange/services/exchange.ts
+++ b/cms-backend/src/api/exchange/services/exchange.ts
@@ -1,0 +1,7 @@
+/**
+ * exchange service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::exchange.exchange');

--- a/cms-backend/src/api/pnk-token-page-buy-section/content-types/pnk-token-page-buy-section/schema.json
+++ b/cms-backend/src/api/pnk-token-page-buy-section/content-types/pnk-token-page-buy-section/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "pnk_token_page_buy_sections",
+  "info": {
+    "singularName": "pnk-token-page-buy-section",
+    "pluralName": "pnk-token-page-buy-sections",
+    "displayName": "PNKTokenPageBuySection",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "buyCards": {
+      "type": "component",
+      "repeatable": true,
+      "component": "pnk-token-page.buy-card"
+    },
+    "exchanges": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::exchange.exchange"
+    }
+  }
+}

--- a/cms-backend/src/api/pnk-token-page-buy-section/controllers/pnk-token-page-buy-section.ts
+++ b/cms-backend/src/api/pnk-token-page-buy-section/controllers/pnk-token-page-buy-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-buy-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::pnk-token-page-buy-section.pnk-token-page-buy-section');

--- a/cms-backend/src/api/pnk-token-page-buy-section/routes/pnk-token-page-buy-section.ts
+++ b/cms-backend/src/api/pnk-token-page-buy-section/routes/pnk-token-page-buy-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-buy-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pnk-token-page-buy-section.pnk-token-page-buy-section');

--- a/cms-backend/src/api/pnk-token-page-buy-section/services/pnk-token-page-buy-section.ts
+++ b/cms-backend/src/api/pnk-token-page-buy-section/services/pnk-token-page-buy-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-buy-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pnk-token-page-buy-section.pnk-token-page-buy-section');

--- a/cms-backend/src/api/pnk-token-page-hero/content-types/pnk-token-page-hero/schema.json
+++ b/cms-backend/src/api/pnk-token-page-hero/content-types/pnk-token-page-hero/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "singleType",
+  "collectionName": "pnk_token_page_heroes",
+  "info": {
+    "singularName": "pnk-token-page-hero",
+    "pluralName": "pnk-token-page-heroes",
+    "displayName": "PNKTokenPageHero",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "buyButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    },
+    "socials": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::social.social"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/src/api/pnk-token-page-hero/controllers/pnk-token-page-hero.ts
+++ b/cms-backend/src/api/pnk-token-page-hero/controllers/pnk-token-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-hero controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::pnk-token-page-hero.pnk-token-page-hero');

--- a/cms-backend/src/api/pnk-token-page-hero/routes/pnk-token-page-hero.ts
+++ b/cms-backend/src/api/pnk-token-page-hero/routes/pnk-token-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-hero router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pnk-token-page-hero.pnk-token-page-hero');

--- a/cms-backend/src/api/pnk-token-page-hero/services/pnk-token-page-hero.ts
+++ b/cms-backend/src/api/pnk-token-page-hero/services/pnk-token-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-hero service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pnk-token-page-hero.pnk-token-page-hero');

--- a/cms-backend/src/api/pnk-token-page-need-section/content-types/pnk-token-page-need-section/schema.json
+++ b/cms-backend/src/api/pnk-token-page-need-section/content-types/pnk-token-page-need-section/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "singleType",
+  "collectionName": "pnk_token_page_need_sections",
+  "info": {
+    "singularName": "pnk-token-page-need-section",
+    "pluralName": "pnk-token-page-need-sections",
+    "displayName": "PNKTokenPageNeedSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "card": {
+      "type": "component",
+      "repeatable": true,
+      "component": "content.cta-card"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": true,
+      "component": "content.button-link"
+    }
+  }
+}

--- a/cms-backend/src/api/pnk-token-page-need-section/controllers/pnk-token-page-need-section.ts
+++ b/cms-backend/src/api/pnk-token-page-need-section/controllers/pnk-token-page-need-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-need-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::pnk-token-page-need-section.pnk-token-page-need-section');

--- a/cms-backend/src/api/pnk-token-page-need-section/routes/pnk-token-page-need-section.ts
+++ b/cms-backend/src/api/pnk-token-page-need-section/routes/pnk-token-page-need-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-need-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pnk-token-page-need-section.pnk-token-page-need-section');

--- a/cms-backend/src/api/pnk-token-page-need-section/services/pnk-token-page-need-section.ts
+++ b/cms-backend/src/api/pnk-token-page-need-section/services/pnk-token-page-need-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-need-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pnk-token-page-need-section.pnk-token-page-need-section');

--- a/cms-backend/src/api/pnk-token-page-tokenomics-section/content-types/pnk-token-page-tokenomics-section/schema.json
+++ b/cms-backend/src/api/pnk-token-page-tokenomics-section/content-types/pnk-token-page-tokenomics-section/schema.json
@@ -1,0 +1,32 @@
+{
+  "kind": "singleType",
+  "collectionName": "pnk_token_page_tokenomics_sections",
+  "info": {
+    "singularName": "pnk-token-page-tokenomics-section",
+    "pluralName": "pnk-token-page-tokenomics-sections",
+    "displayName": "PNKTokenPageTokenomicsSection",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    },
+    "tokenStatDisplay": {
+      "type": "component",
+      "repeatable": false,
+      "component": "pnk-token-page.token-stat-display"
+    }
+  }
+}

--- a/cms-backend/src/api/pnk-token-page-tokenomics-section/controllers/pnk-token-page-tokenomics-section.ts
+++ b/cms-backend/src/api/pnk-token-page-tokenomics-section/controllers/pnk-token-page-tokenomics-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-tokenomics-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section');

--- a/cms-backend/src/api/pnk-token-page-tokenomics-section/routes/pnk-token-page-tokenomics-section.ts
+++ b/cms-backend/src/api/pnk-token-page-tokenomics-section/routes/pnk-token-page-tokenomics-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-tokenomics-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section');

--- a/cms-backend/src/api/pnk-token-page-tokenomics-section/services/pnk-token-page-tokenomics-section.ts
+++ b/cms-backend/src/api/pnk-token-page-tokenomics-section/services/pnk-token-page-tokenomics-section.ts
@@ -1,0 +1,7 @@
+/**
+ * pnk-token-page-tokenomics-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section');

--- a/cms-backend/src/api/token-stat/content-types/token-stat/schema.json
+++ b/cms-backend/src/api/token-stat/content-types/token-stat/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "collectionType",
+  "collectionName": "token_stats",
+  "info": {
+    "singularName": "token-stat",
+    "pluralName": "token-stats",
+    "displayName": "TokenStat"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "key": {
+      "type": "string"
+    },
+    "primaryValue": {
+      "type": "string"
+    },
+    "secondaryValue": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/src/api/token-stat/controllers/token-stat.ts
+++ b/cms-backend/src/api/token-stat/controllers/token-stat.ts
@@ -1,0 +1,7 @@
+/**
+ * token-stat controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::token-stat.token-stat');

--- a/cms-backend/src/api/token-stat/routes/token-stat.ts
+++ b/cms-backend/src/api/token-stat/routes/token-stat.ts
@@ -1,0 +1,7 @@
+/**
+ * token-stat router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::token-stat.token-stat');

--- a/cms-backend/src/api/token-stat/services/token-stat.ts
+++ b/cms-backend/src/api/token-stat/services/token-stat.ts
@@ -1,0 +1,7 @@
+/**
+ * token-stat service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::token-stat.token-stat');

--- a/cms-backend/src/components/pnk-token-page/buy-card.json
+++ b/cms-backend/src/components/pnk-token-page/buy-card.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_pnk_token_page_buy_cards",
+  "info": {
+    "displayName": "buy-card",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "icon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": true
+    },
+    "link": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::link.link"
+    }
+  }
+}

--- a/cms-backend/src/components/pnk-token-page/token-stat-display.json
+++ b/cms-backend/src/components/pnk-token-page/token-stat-display.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_pnk_token_page_token_stat_displays",
+  "info": {
+    "displayName": "TokenStatDisplay"
+  },
+  "options": {},
+  "attributes": {
+    "icon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "stats": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::token-stat.token-stat"
+    }
+  }
+}

--- a/cms-backend/types/generated/components.d.ts
+++ b/cms-backend/types/generated/components.d.ts
@@ -1,5 +1,32 @@
 import type { Struct, Schema } from '@strapi/strapi';
 
+export interface PnkTokenPageTokenStatDisplay extends Struct.ComponentSchema {
+  collectionName: 'components_pnk_token_page_token_stat_displays';
+  info: {
+    displayName: 'TokenStatDisplay';
+  };
+  attributes: {
+    icon: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    stats: Schema.Attribute.Relation<'oneToMany', 'api::token-stat.token-stat'>;
+  };
+}
+
+export interface PnkTokenPageBuyCard extends Struct.ComponentSchema {
+  collectionName: 'components_pnk_token_page_buy_cards';
+  info: {
+    displayName: 'buy-card';
+    description: '';
+  };
+  attributes: {
+    title: Schema.Attribute.String;
+    icon: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios',
+      true
+    >;
+    link: Schema.Attribute.Relation<'oneToOne', 'api::link.link'>;
+  };
+}
+
 export interface ForBuildersPageSolutionSection extends Struct.ComponentSchema {
   collectionName: 'solution_sections';
   info: {
@@ -137,6 +164,8 @@ export interface ContentButtonLink extends Struct.ComponentSchema {
 declare module '@strapi/strapi' {
   export module Public {
     export interface ComponentSchemas {
+      'pnk-token-page.token-stat-display': PnkTokenPageTokenStatDisplay;
+      'pnk-token-page.buy-card': PnkTokenPageBuyCard;
       'for-builders-page.solution-section': ForBuildersPageSolutionSection;
       'for-builders-page.key-challenge': ForBuildersPageKeyChallenge;
       'for-builders-page.get-in-touch-section': ForBuildersPageGetInTouchSection;

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -621,6 +621,34 @@ export interface ApiEarnPageHeroEarnPageHero extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiExchangeExchange extends Struct.CollectionTypeSchema {
+  collectionName: 'exchanges';
+  info: {
+    singularName: 'exchange';
+    pluralName: 'exchanges';
+    displayName: 'Exchange';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    url: Schema.Attribute.String;
+    icon: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::exchange.exchange'
+    >;
+  };
+}
+
 export interface ApiFooterLinksSectionFooterLinksSection
   extends Struct.SingleTypeSchema {
   collectionName: 'footer_links_sections';
@@ -1056,6 +1084,138 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiPnkTokenPageBuySectionPnkTokenPageBuySection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'pnk_token_page_buy_sections';
+  info: {
+    singularName: 'pnk-token-page-buy-section';
+    pluralName: 'pnk-token-page-buy-sections';
+    displayName: 'PNKTokenPageBuySection';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    buyCards: Schema.Attribute.Component<'pnk-token-page.buy-card', true>;
+    exchanges: Schema.Attribute.Relation<'oneToMany', 'api::exchange.exchange'>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::pnk-token-page-buy-section.pnk-token-page-buy-section'
+    >;
+  };
+}
+
+export interface ApiPnkTokenPageHeroPnkTokenPageHero
+  extends Struct.SingleTypeSchema {
+  collectionName: 'pnk_token_page_heroes';
+  info: {
+    singularName: 'pnk-token-page-hero';
+    pluralName: 'pnk-token-page-heroes';
+    displayName: 'PNKTokenPageHero';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    buyButton: Schema.Attribute.Component<'content.button-link', false>;
+    socials: Schema.Attribute.Relation<'oneToMany', 'api::social.social'>;
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::pnk-token-page-hero.pnk-token-page-hero'
+    >;
+  };
+}
+
+export interface ApiPnkTokenPageNeedSectionPnkTokenPageNeedSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'pnk_token_page_need_sections';
+  info: {
+    singularName: 'pnk-token-page-need-section';
+    pluralName: 'pnk-token-page-need-sections';
+    displayName: 'PNKTokenPageNeedSection';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    card: Schema.Attribute.Component<'content.cta-card', true>;
+    arrowLink: Schema.Attribute.Component<'content.button-link', true>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::pnk-token-page-need-section.pnk-token-page-need-section'
+    >;
+  };
+}
+
+export interface ApiPnkTokenPageTokenomicsSectionPnkTokenPageTokenomicsSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'pnk_token_page_tokenomics_sections';
+  info: {
+    singularName: 'pnk-token-page-tokenomics-section';
+    pluralName: 'pnk-token-page-tokenomics-sections';
+    displayName: 'PNKTokenPageTokenomicsSection';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    tokenStatDisplay: Schema.Attribute.Component<
+      'pnk-token-page.token-stat-display',
+      false
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section'
+    >;
+  };
+}
+
 export interface ApiSocialSocial extends Struct.CollectionTypeSchema {
   collectionName: 'socials';
   info: {
@@ -1115,6 +1275,35 @@ export interface ApiSolutionSolution extends Struct.CollectionTypeSchema {
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::solution.solution'
+    >;
+  };
+}
+
+export interface ApiTokenStatTokenStat extends Struct.CollectionTypeSchema {
+  collectionName: 'token_stats';
+  info: {
+    singularName: 'token-stat';
+    pluralName: 'token-stats';
+    displayName: 'TokenStat';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    key: Schema.Attribute.String;
+    primaryValue: Schema.Attribute.String;
+    secondaryValue: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::token-stat.token-stat'
     >;
   };
 }
@@ -1525,6 +1714,7 @@ declare module '@strapi/strapi' {
       'api::earn-page-become-a-curator-tab-content.earn-page-become-a-curator-tab-content': ApiEarnPageBecomeACuratorTabContentEarnPageBecomeACuratorTabContent;
       'api::earn-page-become-a-juror-tab-content.earn-page-become-a-juror-tab-content': ApiEarnPageBecomeAJurorTabContentEarnPageBecomeAJurorTabContent;
       'api::earn-page-hero.earn-page-hero': ApiEarnPageHeroEarnPageHero;
+      'api::exchange.exchange': ApiExchangeExchange;
       'api::footer-links-section.footer-links-section': ApiFooterLinksSectionFooterLinksSection;
       'api::footer-socials-section.footer-socials-section': ApiFooterSocialsSectionFooterSocialsSection;
       'api::footer-subscribe-cta.footer-subscribe-cta': ApiFooterSubscribeCtaFooterSubscribeCta;
@@ -1539,8 +1729,13 @@ declare module '@strapi/strapi' {
       'api::navbar-navlinks-section.navbar-navlinks-section': ApiNavbarNavlinksSectionNavbarNavlinksSection;
       'api::navbar-resources-section.navbar-resources-section': ApiNavbarResourcesSectionNavbarResourcesSection;
       'api::partner.partner': ApiPartnerPartner;
+      'api::pnk-token-page-buy-section.pnk-token-page-buy-section': ApiPnkTokenPageBuySectionPnkTokenPageBuySection;
+      'api::pnk-token-page-hero.pnk-token-page-hero': ApiPnkTokenPageHeroPnkTokenPageHero;
+      'api::pnk-token-page-need-section.pnk-token-page-need-section': ApiPnkTokenPageNeedSectionPnkTokenPageNeedSection;
+      'api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section': ApiPnkTokenPageTokenomicsSectionPnkTokenPageTokenomicsSection;
       'api::social.social': ApiSocialSocial;
       'api::solution.solution': ApiSolutionSolution;
+      'api::token-stat.token-stat': ApiTokenStatTokenStat;
       'api::use-case.use-case': ApiUseCaseUseCase;
       'admin::permission': AdminPermission;
       'admin::user': AdminUser;


### PR DESCRIPTION
## Types added

Collection-Types

1. Exchange
2. TokenStat

Single-Types

1. PNK Token Page Hero
2. PNK Token Page Buy Section
3. PNK Token Page Need Section
4. PNK Token Page Tokenomics Section

Components - PNK Token
1. BuyCard
2. TokenStatDisplay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new content types: `exchange`, `pnk-token-page-buy-section`, `pnk-token-page-hero`, `pnk-token-page-need-section`, `pnk-token-page-tokenomics-section`, and `token-stat`.
	- Added controllers and routers for each new content type to manage API endpoints.
	- Created services for handling business logic related to each new content type.
	- Implemented new components: `buy-card` and `TokenStatDisplay`, with defined attributes and relationships.

- **Bug Fixes**
	- None reported.

- **Documentation**
	- Added documentation comments to new controllers and services for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->