### PR TITLE
feat(cms): community-page-type

### DIFF
--- a/cms-backend/src/api/community-page-hero/content-types/community-page-hero/schema.json
+++ b/cms-backend/src/api/community-page-hero/content-types/community-page-hero/schema.json
@@ -1,0 +1,36 @@
+{
+  "kind": "singleType",
+  "collectionName": "community_page_heroes",
+  "info": {
+    "singularName": "community-page-hero",
+    "pluralName": "community-page-heroes",
+    "displayName": "CommunityPageHero"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "communityButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "content.button-link"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/src/api/community-page-hero/controllers/community-page-hero.ts
+++ b/cms-backend/src/api/community-page-hero/controllers/community-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * community-page-hero controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::community-page-hero.community-page-hero');

--- a/cms-backend/src/api/community-page-hero/routes/community-page-hero.ts
+++ b/cms-backend/src/api/community-page-hero/routes/community-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * community-page-hero router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::community-page-hero.community-page-hero');

--- a/cms-backend/src/api/community-page-hero/services/community-page-hero.ts
+++ b/cms-backend/src/api/community-page-hero/services/community-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * community-page-hero service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::community-page-hero.community-page-hero');

--- a/cms-backend/src/api/community/content-types/community/schema.json
+++ b/cms-backend/src/api/community/content-types/community/schema.json
@@ -1,0 +1,36 @@
+{
+  "kind": "collectionType",
+  "collectionName": "communities",
+  "info": {
+    "singularName": "community",
+    "pluralName": "communities",
+    "displayName": "Community",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "icon": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/cms-backend/src/api/community/controllers/community.ts
+++ b/cms-backend/src/api/community/controllers/community.ts
@@ -1,0 +1,7 @@
+/**
+ * community controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::community.community');

--- a/cms-backend/src/api/community/routes/community.ts
+++ b/cms-backend/src/api/community/routes/community.ts
@@ -1,0 +1,7 @@
+/**
+ * community router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::community.community');

--- a/cms-backend/src/api/community/services/community.ts
+++ b/cms-backend/src/api/community/services/community.ts
@@ -1,0 +1,7 @@
+/**
+ * community service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::community.community');

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -485,6 +485,70 @@ export interface PluginUsersPermissionsUser
   };
 }
 
+export interface ApiCommunityCommunity extends Struct.CollectionTypeSchema {
+  collectionName: 'communities';
+  info: {
+    singularName: 'community';
+    pluralName: 'communities';
+    displayName: 'Community';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Schema.Attribute.String;
+    url: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    icon: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::community.community'
+    >;
+  };
+}
+
+export interface ApiCommunityPageHeroCommunityPageHero
+  extends Struct.SingleTypeSchema {
+  collectionName: 'community_page_heroes';
+  info: {
+    singularName: 'community-page-hero';
+    pluralName: 'community-page-heroes';
+    displayName: 'CommunityPageHero';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    communityButtons: Schema.Attribute.Component<'content.button-link', true>;
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::community-page-hero.community-page-hero'
+    >;
+  };
+}
+
 export interface ApiCourtCourt extends Struct.CollectionTypeSchema {
   collectionName: 'courts';
   info: {
@@ -1746,6 +1810,8 @@ declare module '@strapi/strapi' {
       'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::community.community': ApiCommunityCommunity;
+      'api::community-page-hero.community-page-hero': ApiCommunityPageHeroCommunityPageHero;
       'api::court.court': ApiCourtCourt;
       'api::earn-page-become-a-curator-tab-content.earn-page-become-a-curator-tab-content': ApiEarnPageBecomeACuratorTabContentEarnPageBecomeACuratorTabContent;
       'api::earn-page-become-a-juror-tab-content.earn-page-become-a-juror-tab-content': ApiEarnPageBecomeAJurorTabContentEarnPageBecomeAJurorTabContent;


### PR DESCRIPTION
## Adds Types for Community page

CollectionType
- Community

SingleType
- CommunityPageHero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new content type schema for "Community Page Hero" with fields for header, subtitle, community buttons, and background media.
	- Added a new collection type for "Community" with attributes for title, URL, subtitle, and an optional icon field.
	- Created controllers, routers, and services for both "Community Page Hero" and "Community".

- **Documentation**
	- Added documentation comments in new files for clarity on the purpose of controllers, routers, and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->