### PR TITLE
feat(cms): cooperative-page-types

### DIFF
--- a/cms-backend/src/api/annual-report/content-types/annual-report/schema.json
+++ b/cms-backend/src/api/annual-report/content-types/annual-report/schema.json
@@ -1,0 +1,21 @@
+{
+  "kind": "collectionType",
+  "collectionName": "annual_reports",
+  "info": {
+    "singularName": "annual-report",
+    "pluralName": "annual-reports",
+    "displayName": "Annual Report"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "year": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/src/api/annual-report/content-types/annual-report/schema.json
+++ b/cms-backend/src/api/annual-report/content-types/annual-report/schema.json
@@ -4,18 +4,19 @@
   "info": {
     "singularName": "annual-report",
     "pluralName": "annual-reports",
-    "displayName": "Annual Report"
+    "displayName": "Annual Report",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
   },
   "pluginOptions": {},
   "attributes": {
-    "year": {
-      "type": "string"
-    },
     "url": {
       "type": "string"
+    },
+    "year": {
+      "type": "integer"
     }
   }
 }

--- a/cms-backend/src/api/annual-report/controllers/annual-report.ts
+++ b/cms-backend/src/api/annual-report/controllers/annual-report.ts
@@ -1,0 +1,7 @@
+/**
+ * annual-report controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::annual-report.annual-report');

--- a/cms-backend/src/api/annual-report/routes/annual-report.ts
+++ b/cms-backend/src/api/annual-report/routes/annual-report.ts
@@ -1,0 +1,7 @@
+/**
+ * annual-report router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::annual-report.annual-report');

--- a/cms-backend/src/api/annual-report/services/annual-report.ts
+++ b/cms-backend/src/api/annual-report/services/annual-report.ts
@@ -1,0 +1,7 @@
+/**
+ * annual-report service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::annual-report.annual-report');

--- a/cms-backend/src/api/cooperative-page-hero/content-types/cooperative-page-hero/schema.json
+++ b/cms-backend/src/api/cooperative-page-hero/content-types/cooperative-page-hero/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "singleType",
+  "collectionName": "cooperative_page_heroes",
+  "info": {
+    "singularName": "cooperative-page-hero",
+    "pluralName": "cooperative-page-heroes",
+    "displayName": "CooperativePageHero"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "buttons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "content.button-link"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    }
+  }
+}

--- a/cms-backend/src/api/cooperative-page-hero/content-types/cooperative-page-hero/schema.json
+++ b/cms-backend/src/api/cooperative-page-hero/content-types/cooperative-page-hero/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "cooperative-page-hero",
     "pluralName": "cooperative-page-heroes",
-    "displayName": "CooperativePageHero"
+    "displayName": "CooperativePageHero",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -26,6 +27,16 @@
       "type": "component",
       "repeatable": false,
       "component": "content.button-link"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/cms-backend/src/api/cooperative-page-hero/controllers/cooperative-page-hero.ts
+++ b/cms-backend/src/api/cooperative-page-hero/controllers/cooperative-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-hero controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::cooperative-page-hero.cooperative-page-hero');

--- a/cms-backend/src/api/cooperative-page-hero/routes/cooperative-page-hero.ts
+++ b/cms-backend/src/api/cooperative-page-hero/routes/cooperative-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-hero router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::cooperative-page-hero.cooperative-page-hero');

--- a/cms-backend/src/api/cooperative-page-hero/services/cooperative-page-hero.ts
+++ b/cms-backend/src/api/cooperative-page-hero/services/cooperative-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-hero service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::cooperative-page-hero.cooperative-page-hero');

--- a/cms-backend/src/api/cooperative-page-member-section/content-types/cooperative-page-member-section/schema.json
+++ b/cms-backend/src/api/cooperative-page-member-section/content-types/cooperative-page-member-section/schema.json
@@ -1,0 +1,35 @@
+{
+  "kind": "singleType",
+  "collectionName": "cooperative_page_member_sections",
+  "info": {
+    "singularName": "cooperative-page-member-section",
+    "pluralName": "cooperative-page-member-sections",
+    "displayName": "CooperativePageMemberSection",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "learnMoreSection": {
+      "type": "component",
+      "repeatable": false,
+      "component": "cooperative-report-page.learn-more-section"
+    },
+    "SecondaryHeader": {
+      "type": "string"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    }
+  }
+}

--- a/cms-backend/src/api/cooperative-page-member-section/controllers/cooperative-page-member-section.ts
+++ b/cms-backend/src/api/cooperative-page-member-section/controllers/cooperative-page-member-section.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-member-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::cooperative-page-member-section.cooperative-page-member-section');

--- a/cms-backend/src/api/cooperative-page-member-section/routes/cooperative-page-member-section.ts
+++ b/cms-backend/src/api/cooperative-page-member-section/routes/cooperative-page-member-section.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-member-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::cooperative-page-member-section.cooperative-page-member-section');

--- a/cms-backend/src/api/cooperative-page-member-section/services/cooperative-page-member-section.ts
+++ b/cms-backend/src/api/cooperative-page-member-section/services/cooperative-page-member-section.ts
@@ -1,0 +1,7 @@
+/**
+ * cooperative-page-member-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::cooperative-page-member-section.cooperative-page-member-section');

--- a/cms-backend/src/api/risk-report/content-types/risk-report/schema.json
+++ b/cms-backend/src/api/risk-report/content-types/risk-report/schema.json
@@ -4,21 +4,36 @@
   "info": {
     "singularName": "risk-report",
     "pluralName": "risk-reports",
-    "displayName": "Risk Report"
+    "displayName": "Risk Report",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
   },
   "pluginOptions": {},
   "attributes": {
-    "year": {
+    "url": {
       "type": "string"
     },
     "month": {
-      "type": "string"
+      "type": "enumeration",
+      "enum": [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+      ]
     },
-    "url": {
-      "type": "string"
+    "year": {
+      "type": "integer"
     }
   }
 }

--- a/cms-backend/src/api/risk-report/content-types/risk-report/schema.json
+++ b/cms-backend/src/api/risk-report/content-types/risk-report/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "collectionType",
+  "collectionName": "risk_reports",
+  "info": {
+    "singularName": "risk-report",
+    "pluralName": "risk-reports",
+    "displayName": "Risk Report"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "year": {
+      "type": "string"
+    },
+    "month": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/src/api/risk-report/controllers/risk-report.ts
+++ b/cms-backend/src/api/risk-report/controllers/risk-report.ts
@@ -1,0 +1,7 @@
+/**
+ * risk-report controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::risk-report.risk-report');

--- a/cms-backend/src/api/risk-report/routes/risk-report.ts
+++ b/cms-backend/src/api/risk-report/routes/risk-report.ts
@@ -1,0 +1,7 @@
+/**
+ * risk-report router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::risk-report.risk-report');

--- a/cms-backend/src/api/risk-report/services/risk-report.ts
+++ b/cms-backend/src/api/risk-report/services/risk-report.ts
@@ -1,0 +1,7 @@
+/**
+ * risk-report service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::risk-report.risk-report');

--- a/cms-backend/src/api/treasury-report/content-types/treasury-report/schema.json
+++ b/cms-backend/src/api/treasury-report/content-types/treasury-report/schema.json
@@ -4,21 +4,36 @@
   "info": {
     "singularName": "treasury-report",
     "pluralName": "treasury-reports",
-    "displayName": "Treasury Report"
+    "displayName": "Treasury Report",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
   },
   "pluginOptions": {},
   "attributes": {
-    "year": {
+    "url": {
       "type": "string"
     },
     "month": {
-      "type": "string"
+      "type": "enumeration",
+      "enum": [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+      ]
     },
-    "url": {
-      "type": "string"
+    "year": {
+      "type": "integer"
     }
   }
 }

--- a/cms-backend/src/api/treasury-report/content-types/treasury-report/schema.json
+++ b/cms-backend/src/api/treasury-report/content-types/treasury-report/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "collectionType",
+  "collectionName": "treasury_reports",
+  "info": {
+    "singularName": "treasury-report",
+    "pluralName": "treasury-reports",
+    "displayName": "Treasury Report"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "year": {
+      "type": "string"
+    },
+    "month": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/src/api/treasury-report/controllers/treasury-report.ts
+++ b/cms-backend/src/api/treasury-report/controllers/treasury-report.ts
@@ -1,0 +1,7 @@
+/**
+ * treasury-report controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::treasury-report.treasury-report');

--- a/cms-backend/src/api/treasury-report/routes/treasury-report.ts
+++ b/cms-backend/src/api/treasury-report/routes/treasury-report.ts
@@ -1,0 +1,7 @@
+/**
+ * treasury-report router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::treasury-report.treasury-report');

--- a/cms-backend/src/api/treasury-report/services/treasury-report.ts
+++ b/cms-backend/src/api/treasury-report/services/treasury-report.ts
@@ -1,0 +1,7 @@
+/**
+ * treasury-report service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::treasury-report.treasury-report');

--- a/cms-backend/src/components/cooperative-report-page/learn-more-section.json
+++ b/cms-backend/src/components/cooperative-report-page/learn-more-section.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_cooperative_report_page_learn_more_sections",
+  "info": {
+    "displayName": "LearnMoreSection",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "button": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/src/components/cooperative-report-page/report-card.json
+++ b/cms-backend/src/components/cooperative-report-page/report-card.json
@@ -1,0 +1,33 @@
+{
+  "collectionName": "components_cooperative_report_page_report_cards",
+  "info": {
+    "displayName": "ReportCard"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "ReportType": {
+      "type": "enumeration",
+      "enum": [
+        "annual",
+        "treasury",
+        "risk"
+      ]
+    },
+    "icon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/types/generated/components.d.ts
+++ b/cms-backend/types/generated/components.d.ts
@@ -83,6 +83,36 @@ export interface EarnPageEnterCourtSection extends Struct.ComponentSchema {
   };
 }
 
+export interface CooperativeReportPageReportCard
+  extends Struct.ComponentSchema {
+  collectionName: 'components_cooperative_report_page_report_cards';
+  info: {
+    displayName: 'ReportCard';
+  };
+  attributes: {
+    title: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    ReportType: Schema.Attribute.Enumeration<['annual', 'treasury', 'risk']>;
+    icon: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+  };
+}
+
+export interface CooperativeReportPageLearnMoreSection
+  extends Struct.ComponentSchema {
+  collectionName: 'components_cooperative_report_page_learn_more_sections';
+  info: {
+    displayName: 'LearnMoreSection';
+    description: '';
+  };
+  attributes: {
+    Title: Schema.Attribute.String;
+    button: Schema.Attribute.Component<'content.button-link', false>;
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
+  };
+}
+
 export interface ContentStatDisplay extends Struct.ComponentSchema {
   collectionName: 'components_content_stat_display';
   info: {
@@ -154,6 +184,8 @@ declare module '@strapi/strapi' {
       'for-builders-page.get-in-touch-section': ForBuildersPageGetInTouchSection;
       'earn-page.kleros-scout-section': EarnPageKlerosScoutSection;
       'earn-page.enter-court-section': EarnPageEnterCourtSection;
+      'cooperative-report-page.report-card': CooperativeReportPageReportCard;
+      'cooperative-report-page.learn-more-section': CooperativeReportPageLearnMoreSection;
       'content.stat-display': ContentStatDisplay;
       'content.section': ContentSection;
       'content.navlink': ContentNavlink;

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -556,13 +556,14 @@ export interface ApiAnnualReportAnnualReport
     singularName: 'annual-report';
     pluralName: 'annual-reports';
     displayName: 'Annual Report';
+    description: '';
   };
   options: {
     draftAndPublish: true;
   };
   attributes: {
-    year: Schema.Attribute.String;
     url: Schema.Attribute.String;
+    year: Schema.Attribute.Integer;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;
@@ -1391,14 +1392,30 @@ export interface ApiRiskReportRiskReport extends Struct.CollectionTypeSchema {
     singularName: 'risk-report';
     pluralName: 'risk-reports';
     displayName: 'Risk Report';
+    description: '';
   };
   options: {
     draftAndPublish: true;
   };
   attributes: {
-    year: Schema.Attribute.String;
-    month: Schema.Attribute.String;
     url: Schema.Attribute.String;
+    month: Schema.Attribute.Enumeration<
+      [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ]
+    >;
+    year: Schema.Attribute.Integer;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;
@@ -1544,14 +1561,30 @@ export interface ApiTreasuryReportTreasuryReport
     singularName: 'treasury-report';
     pluralName: 'treasury-reports';
     displayName: 'Treasury Report';
+    description: '';
   };
   options: {
     draftAndPublish: true;
   };
   attributes: {
-    year: Schema.Attribute.String;
-    month: Schema.Attribute.String;
     url: Schema.Attribute.String;
+    month: Schema.Attribute.Enumeration<
+      [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ]
+    >;
+    year: Schema.Attribute.Integer;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -585,6 +585,7 @@ export interface ApiCooperativePageHeroCooperativePageHero
     singularName: 'cooperative-page-hero';
     pluralName: 'cooperative-page-heroes';
     displayName: 'CooperativePageHero';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -594,6 +595,9 @@ export interface ApiCooperativePageHeroCooperativePageHero
     subtitle: Schema.Attribute.String;
     buttons: Schema.Attribute.Component<'content.button-link', true>;
     arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
     createdAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     publishedAt: Schema.Attribute.DateTime;

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -549,6 +549,102 @@ export interface ApiCommunityPageHeroCommunityPageHero
   };
 }
 
+export interface ApiAnnualReportAnnualReport
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'annual_reports';
+  info: {
+    singularName: 'annual-report';
+    pluralName: 'annual-reports';
+    displayName: 'Annual Report';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    year: Schema.Attribute.String;
+    url: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::annual-report.annual-report'
+    >;
+  };
+}
+
+export interface ApiCooperativePageHeroCooperativePageHero
+  extends Struct.SingleTypeSchema {
+  collectionName: 'cooperative_page_heroes';
+  info: {
+    singularName: 'cooperative-page-hero';
+    pluralName: 'cooperative-page-heroes';
+    displayName: 'CooperativePageHero';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    buttons: Schema.Attribute.Component<'content.button-link', true>;
+    arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::cooperative-page-hero.cooperative-page-hero'
+    >;
+  };
+}
+
+export interface ApiCooperativePageMemberSectionCooperativePageMemberSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'cooperative_page_member_sections';
+  info: {
+    singularName: 'cooperative-page-member-section';
+    pluralName: 'cooperative-page-member-sections';
+    displayName: 'CooperativePageMemberSection';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    Header: Schema.Attribute.String;
+    subtitle: Schema.Attribute.String;
+    learnMoreSection: Schema.Attribute.Component<
+      'cooperative-report-page.learn-more-section',
+      false
+    >;
+    SecondaryHeader: Schema.Attribute.String;
+    arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::cooperative-page-member-section.cooperative-page-member-section'
+    >;
+  };
+}
+
 export interface ApiCourtCourt extends Struct.CollectionTypeSchema {
   collectionName: 'courts';
   info: {
@@ -1285,6 +1381,35 @@ export interface ApiPnkTokenPageTokenomicsSectionPnkTokenPageTokenomicsSection
   };
 }
 
+export interface ApiRiskReportRiskReport extends Struct.CollectionTypeSchema {
+  collectionName: 'risk_reports';
+  info: {
+    singularName: 'risk-report';
+    pluralName: 'risk-reports';
+    displayName: 'Risk Report';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    year: Schema.Attribute.String;
+    month: Schema.Attribute.String;
+    url: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::risk-report.risk-report'
+    >;
+  };
+}
+
 export interface ApiSocialSocial extends Struct.CollectionTypeSchema {
   collectionName: 'socials';
   info: {
@@ -1404,6 +1529,36 @@ export interface ApiTokenStatTokenStat extends Struct.CollectionTypeSchema {
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::token-stat.token-stat'
+    >;
+  };
+}
+
+export interface ApiTreasuryReportTreasuryReport
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'treasury_reports';
+  info: {
+    singularName: 'treasury-report';
+    pluralName: 'treasury-reports';
+    displayName: 'Treasury Report';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    year: Schema.Attribute.String;
+    month: Schema.Attribute.String;
+    url: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    publishedAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::treasury-report.treasury-report'
     >;
   };
 }
@@ -1812,6 +1967,9 @@ declare module '@strapi/strapi' {
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::community.community': ApiCommunityCommunity;
       'api::community-page-hero.community-page-hero': ApiCommunityPageHeroCommunityPageHero;
+      'api::annual-report.annual-report': ApiAnnualReportAnnualReport;
+      'api::cooperative-page-hero.cooperative-page-hero': ApiCooperativePageHeroCooperativePageHero;
+      'api::cooperative-page-member-section.cooperative-page-member-section': ApiCooperativePageMemberSectionCooperativePageMemberSection;
       'api::court.court': ApiCourtCourt;
       'api::earn-page-become-a-curator-tab-content.earn-page-become-a-curator-tab-content': ApiEarnPageBecomeACuratorTabContentEarnPageBecomeACuratorTabContent;
       'api::earn-page-become-a-juror-tab-content.earn-page-become-a-juror-tab-content': ApiEarnPageBecomeAJurorTabContentEarnPageBecomeAJurorTabContent;
@@ -1835,10 +1993,12 @@ declare module '@strapi/strapi' {
       'api::pnk-token-page-hero.pnk-token-page-hero': ApiPnkTokenPageHeroPnkTokenPageHero;
       'api::pnk-token-page-need-section.pnk-token-page-need-section': ApiPnkTokenPageNeedSectionPnkTokenPageNeedSection;
       'api::pnk-token-page-tokenomics-section.pnk-token-page-tokenomics-section': ApiPnkTokenPageTokenomicsSectionPnkTokenPageTokenomicsSection;
+      'api::risk-report.risk-report': ApiRiskReportRiskReport;
       'api::social.social': ApiSocialSocial;
       'api::solution.solution': ApiSolutionSolution;
       'api::token-explorer.token-explorer': ApiTokenExplorerTokenExplorer;
       'api::token-stat.token-stat': ApiTokenStatTokenStat;
+      'api::treasury-report.treasury-report': ApiTreasuryReportTreasuryReport;
       'api::use-case.use-case': ApiUseCaseUseCase;
       'admin::permission': AdminPermission;
       'admin::user': AdminUser;


### PR DESCRIPTION
Adds types for Cooperative page

Single Type
- CooperativePageHero
- CooperativePageMemberSection

Collection Type
- Annual Report
- Risk Report
- Treasury Report

Component
- ReportCard
- LearnMore Section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Content Types**
	- Added Annual Report collection
	- Added Cooperative Page Hero collection
	- Added Cooperative Page Member Section collection
	- Added Risk Report collection
	- Added Treasury Report collection

- **New Components**
	- Added Learn More Section component
	- Added Report Card component

- **Backend Updates**
	- Implemented controllers, routes, and services for new content types
	- Configured schema definitions for new collections and components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->