### PR TITLE
feat(cms): types for brand assets page

### DIFF
--- a/cms-backend/src/api/brand-assets-page-hero/content-types/brand-assets-page-hero/schema.json
+++ b/cms-backend/src/api/brand-assets-page-hero/content-types/brand-assets-page-hero/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_heroes",
+  "info": {
+    "singularName": "brand-assets-page-hero",
+    "pluralName": "brand-assets-page-heroes",
+    "displayName": "BrandAssetsPageHero",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "button": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-hero/controllers/brand-assets-page-hero.ts
+++ b/cms-backend/src/api/brand-assets-page-hero/controllers/brand-assets-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-hero controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-hero.brand-assets-page-hero');

--- a/cms-backend/src/api/brand-assets-page-hero/routes/brand-assets-page-hero.ts
+++ b/cms-backend/src/api/brand-assets-page-hero/routes/brand-assets-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-hero router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-hero.brand-assets-page-hero');

--- a/cms-backend/src/api/brand-assets-page-hero/services/brand-assets-page-hero.ts
+++ b/cms-backend/src/api/brand-assets-page-hero/services/brand-assets-page-hero.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-hero service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-hero.brand-assets-page-hero');

--- a/cms-backend/src/api/brand-assets-page-kleros-badges-section/content-types/brand-assets-page-kleros-badges-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-kleros-badges-section/content-types/brand-assets-page-kleros-badges-section/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_kleros_badges_sections",
+  "info": {
+    "singularName": "brand-assets-page-kleros-badges-section",
+    "pluralName": "brand-assets-page-kleros-badges-sections",
+    "displayName": "BrandAssetsPageKlerosBadgesSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "imageDownloads": {
+      "type": "component",
+      "repeatable": true,
+      "component": "brand-assets-page.image-download"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-kleros-badges-section/controllers/brand-assets-page-kleros-badges-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-badges-section/controllers/brand-assets-page-kleros-badges-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-badges-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-kleros-badges-section.brand-assets-page-kleros-badges-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-badges-section/routes/brand-assets-page-kleros-badges-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-badges-section/routes/brand-assets-page-kleros-badges-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-badges-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-kleros-badges-section.brand-assets-page-kleros-badges-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-badges-section/services/brand-assets-page-kleros-badges-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-badges-section/services/brand-assets-page-kleros-badges-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-badges-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-kleros-badges-section.brand-assets-page-kleros-badges-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-colors-section/content-types/brand-assets-page-kleros-colors-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-kleros-colors-section/content-types/brand-assets-page-kleros-colors-section/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_kleros_colors_sections",
+  "info": {
+    "singularName": "brand-assets-page-kleros-colors-section",
+    "pluralName": "brand-assets-page-kleros-colors-sections",
+    "displayName": "BrandAssetsPageKlerosColorsSection",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "colorCards": {
+      "type": "component",
+      "repeatable": true,
+      "component": "brand-assets-page.color-card"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-kleros-colors-section/controllers/brand-assets-page-kleros-colors-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-colors-section/controllers/brand-assets-page-kleros-colors-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-colors-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-kleros-colors-section.brand-assets-page-kleros-colors-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-colors-section/routes/brand-assets-page-kleros-colors-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-colors-section/routes/brand-assets-page-kleros-colors-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-colors-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-kleros-colors-section.brand-assets-page-kleros-colors-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-colors-section/services/brand-assets-page-kleros-colors-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-colors-section/services/brand-assets-page-kleros-colors-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-colors-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-kleros-colors-section.brand-assets-page-kleros-colors-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-fonts-section/content-types/brand-assets-page-kleros-fonts-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-kleros-fonts-section/content-types/brand-assets-page-kleros-fonts-section/schema.json
@@ -1,0 +1,23 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_kleros_fonts_sections",
+  "info": {
+    "singularName": "brand-assets-page-kleros-fonts-section",
+    "pluralName": "brand-assets-page-kleros-fonts-sections",
+    "displayName": "BrandAssetsPageKlerosFontsSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "linkCard": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.link-card"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-kleros-fonts-section/controllers/brand-assets-page-kleros-fonts-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-fonts-section/controllers/brand-assets-page-kleros-fonts-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-fonts-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-kleros-fonts-section.brand-assets-page-kleros-fonts-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-fonts-section/routes/brand-assets-page-kleros-fonts-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-fonts-section/routes/brand-assets-page-kleros-fonts-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-fonts-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-kleros-fonts-section.brand-assets-page-kleros-fonts-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-fonts-section/services/brand-assets-page-kleros-fonts-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-fonts-section/services/brand-assets-page-kleros-fonts-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-fonts-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-kleros-fonts-section.brand-assets-page-kleros-fonts-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-logo-section/content-types/brand-assets-page-kleros-logo-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-kleros-logo-section/content-types/brand-assets-page-kleros-logo-section/schema.json
@@ -1,0 +1,23 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_kleros_logo_sections",
+  "info": {
+    "singularName": "brand-assets-page-kleros-logo-section",
+    "pluralName": "brand-assets-page-kleros-logo-sections",
+    "displayName": "BrandAssetsPageKlerosLogoSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "imageDownloads": {
+      "type": "component",
+      "repeatable": true,
+      "component": "brand-assets-page.image-download"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-kleros-logo-section/controllers/brand-assets-page-kleros-logo-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-logo-section/controllers/brand-assets-page-kleros-logo-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-logo-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-kleros-logo-section.brand-assets-page-kleros-logo-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-logo-section/routes/brand-assets-page-kleros-logo-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-logo-section/routes/brand-assets-page-kleros-logo-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-logo-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-kleros-logo-section.brand-assets-page-kleros-logo-section');

--- a/cms-backend/src/api/brand-assets-page-kleros-logo-section/services/brand-assets-page-kleros-logo-section.ts
+++ b/cms-backend/src/api/brand-assets-page-kleros-logo-section/services/brand-assets-page-kleros-logo-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-kleros-logo-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-kleros-logo-section.brand-assets-page-kleros-logo-section');

--- a/cms-backend/src/api/brand-assets-page-logos-package-section/content-types/brand-assets-page-logos-package-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-logos-package-section/content-types/brand-assets-page-logos-package-section/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_logos_package_sections",
+  "info": {
+    "singularName": "brand-assets-page-logos-package-section",
+    "pluralName": "brand-assets-page-logos-package-sections",
+    "displayName": "BrandAssetsPageLogosPackageSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "button": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-logos-package-section/controllers/brand-assets-page-logos-package-section.ts
+++ b/cms-backend/src/api/brand-assets-page-logos-package-section/controllers/brand-assets-page-logos-package-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-logos-package-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-logos-package-section.brand-assets-page-logos-package-section');

--- a/cms-backend/src/api/brand-assets-page-logos-package-section/routes/brand-assets-page-logos-package-section.ts
+++ b/cms-backend/src/api/brand-assets-page-logos-package-section/routes/brand-assets-page-logos-package-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-logos-package-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-logos-package-section.brand-assets-page-logos-package-section');

--- a/cms-backend/src/api/brand-assets-page-logos-package-section/services/brand-assets-page-logos-package-section.ts
+++ b/cms-backend/src/api/brand-assets-page-logos-package-section/services/brand-assets-page-logos-package-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-logos-package-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-logos-package-section.brand-assets-page-logos-package-section');

--- a/cms-backend/src/api/brand-assets-page-pnk-token-section/content-types/brand-assets-page-pnk-token-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-pnk-token-section/content-types/brand-assets-page-pnk-token-section/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_pnk_token_sections",
+  "info": {
+    "singularName": "brand-assets-page-pnk-token-section",
+    "pluralName": "brand-assets-page-pnk-token-sections",
+    "displayName": "BrandAssetsPagePNKTokenSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "imageDownload": {
+      "type": "component",
+      "repeatable": false,
+      "component": "brand-assets-page.image-download"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-pnk-token-section/controllers/brand-assets-page-pnk-token-section.ts
+++ b/cms-backend/src/api/brand-assets-page-pnk-token-section/controllers/brand-assets-page-pnk-token-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-pnk-token-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-pnk-token-section.brand-assets-page-pnk-token-section');

--- a/cms-backend/src/api/brand-assets-page-pnk-token-section/routes/brand-assets-page-pnk-token-section.ts
+++ b/cms-backend/src/api/brand-assets-page-pnk-token-section/routes/brand-assets-page-pnk-token-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-pnk-token-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-pnk-token-section.brand-assets-page-pnk-token-section');

--- a/cms-backend/src/api/brand-assets-page-pnk-token-section/services/brand-assets-page-pnk-token-section.ts
+++ b/cms-backend/src/api/brand-assets-page-pnk-token-section/services/brand-assets-page-pnk-token-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-pnk-token-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-pnk-token-section.brand-assets-page-pnk-token-section');

--- a/cms-backend/src/api/brand-assets-page-styled-images-section/content-types/brand-assets-page-styled-images-section/schema.json
+++ b/cms-backend/src/api/brand-assets-page-styled-images-section/content-types/brand-assets-page-styled-images-section/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "singleType",
+  "collectionName": "brand_assets_page_styled_images_sections",
+  "info": {
+    "singularName": "brand-assets-page-styled-images-section",
+    "pluralName": "brand-assets-page-styled-images-sections",
+    "displayName": "BrandAssetsPageStyledImagesSection"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "header": {
+      "type": "string"
+    },
+    "wallpapersHeader": {
+      "type": "string"
+    },
+    "wallpapersSubtitle": {
+      "type": "string"
+    },
+    "wallpapersImageDownloads": {
+      "type": "component",
+      "repeatable": true,
+      "component": "brand-assets-page.image-download"
+    },
+    "productMockupsHeader": {
+      "type": "string"
+    },
+    "productMockupsSubtitle": {
+      "type": "string"
+    },
+    "productMockupsImageDownloads": {
+      "type": "component",
+      "repeatable": true,
+      "component": "brand-assets-page.image-download"
+    }
+  }
+}

--- a/cms-backend/src/api/brand-assets-page-styled-images-section/controllers/brand-assets-page-styled-images-section.ts
+++ b/cms-backend/src/api/brand-assets-page-styled-images-section/controllers/brand-assets-page-styled-images-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-styled-images-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::brand-assets-page-styled-images-section.brand-assets-page-styled-images-section');

--- a/cms-backend/src/api/brand-assets-page-styled-images-section/routes/brand-assets-page-styled-images-section.ts
+++ b/cms-backend/src/api/brand-assets-page-styled-images-section/routes/brand-assets-page-styled-images-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-styled-images-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand-assets-page-styled-images-section.brand-assets-page-styled-images-section');

--- a/cms-backend/src/api/brand-assets-page-styled-images-section/services/brand-assets-page-styled-images-section.ts
+++ b/cms-backend/src/api/brand-assets-page-styled-images-section/services/brand-assets-page-styled-images-section.ts
@@ -1,0 +1,7 @@
+/**
+ * brand-assets-page-styled-images-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand-assets-page-styled-images-section.brand-assets-page-styled-images-section');

--- a/cms-backend/src/components/brand-assets-page/color-card.json
+++ b/cms-backend/src/components/brand-assets-page/color-card.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_brand_assets_page_color_cards",
+  "info": {
+    "displayName": "colorCard"
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "hexColor": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/src/components/brand-assets-page/image-download.json
+++ b/cms-backend/src/components/brand-assets-page/image-download.json
@@ -1,0 +1,29 @@
+{
+  "collectionName": "components_brand_assets_page_image_downloads",
+  "info": {
+    "displayName": "imageDownload",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "svgDownloadLink": {
+      "type": "string"
+    },
+    "pngDownloadLink": {
+      "type": "string"
+    }
+  }
+}

--- a/cms-backend/types/generated/components.d.ts
+++ b/cms-backend/types/generated/components.d.ts
@@ -1,5 +1,30 @@
 import type { Schema, Struct } from '@strapi/strapi';
 
+export interface BrandAssetsPageColorCard extends Struct.ComponentSchema {
+  collectionName: 'components_brand_assets_page_color_cards';
+  info: {
+    displayName: 'colorCard';
+  };
+  attributes: {
+    hexColor: Schema.Attribute.String;
+    name: Schema.Attribute.String;
+  };
+}
+
+export interface BrandAssetsPageImageDownload extends Struct.ComponentSchema {
+  collectionName: 'components_brand_assets_page_image_downloads';
+  info: {
+    description: '';
+    displayName: 'imageDownload';
+  };
+  attributes: {
+    image: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    name: Schema.Attribute.String;
+    pngDownloadLink: Schema.Attribute.String;
+    svgDownloadLink: Schema.Attribute.String;
+  };
+}
+
 export interface ContentButtonLink extends Struct.ComponentSchema {
   collectionName: 'components_content_button_links';
   info: {
@@ -238,6 +263,8 @@ export interface RAndDPageWaitlistSection extends Struct.ComponentSchema {
 declare module '@strapi/strapi' {
   export module Public {
     export interface ComponentSchemas {
+      'brand-assets-page.color-card': BrandAssetsPageColorCard;
+      'brand-assets-page.image-download': BrandAssetsPageImageDownload;
       'content.button-link': ContentButtonLink;
       'content.cta-card': ContentCtaCard;
       'content.link-card': ContentLinkCard;

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -400,6 +400,280 @@ export interface ApiAnnualReportAnnualReport
   };
 }
 
+export interface ApiBrandAssetsPageHeroBrandAssetsPageHero
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_heroes';
+  info: {
+    description: '';
+    displayName: 'BrandAssetsPageHero';
+    pluralName: 'brand-assets-page-heroes';
+    singularName: 'brand-assets-page-hero';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
+    button: Schema.Attribute.Component<'content.button-link', false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-hero.brand-assets-page-hero'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subtitle: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageKlerosBadgesSectionBrandAssetsPageKlerosBadgesSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_kleros_badges_sections';
+  info: {
+    displayName: 'BrandAssetsPageKlerosBadgesSection';
+    pluralName: 'brand-assets-page-kleros-badges-sections';
+    singularName: 'brand-assets-page-kleros-badges-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    imageDownloads: Schema.Attribute.Component<
+      'brand-assets-page.image-download',
+      true
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-kleros-badges-section.brand-assets-page-kleros-badges-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subtitle: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageKlerosColorsSectionBrandAssetsPageKlerosColorsSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_kleros_colors_sections';
+  info: {
+    description: '';
+    displayName: 'BrandAssetsPageKlerosColorsSection';
+    pluralName: 'brand-assets-page-kleros-colors-sections';
+    singularName: 'brand-assets-page-kleros-colors-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    colorCards: Schema.Attribute.Component<
+      'brand-assets-page.color-card',
+      true
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-kleros-colors-section.brand-assets-page-kleros-colors-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subtitle: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageKlerosFontsSectionBrandAssetsPageKlerosFontsSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_kleros_fonts_sections';
+  info: {
+    displayName: 'BrandAssetsPageKlerosFontsSection';
+    pluralName: 'brand-assets-page-kleros-fonts-sections';
+    singularName: 'brand-assets-page-kleros-fonts-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    linkCard: Schema.Attribute.Component<'content.link-card', false>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-kleros-fonts-section.brand-assets-page-kleros-fonts-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageKlerosLogoSectionBrandAssetsPageKlerosLogoSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_kleros_logo_sections';
+  info: {
+    displayName: 'BrandAssetsPageKlerosLogoSection';
+    pluralName: 'brand-assets-page-kleros-logo-sections';
+    singularName: 'brand-assets-page-kleros-logo-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    imageDownloads: Schema.Attribute.Component<
+      'brand-assets-page.image-download',
+      true
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-kleros-logo-section.brand-assets-page-kleros-logo-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageLogosPackageSectionBrandAssetsPageLogosPackageSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_logos_package_sections';
+  info: {
+    displayName: 'BrandAssetsPageLogosPackageSection';
+    pluralName: 'brand-assets-page-logos-package-sections';
+    singularName: 'brand-assets-page-logos-package-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    button: Schema.Attribute.Component<'content.button-link', false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-logos-package-section.brand-assets-page-logos-package-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subtitle: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPagePnkTokenSectionBrandAssetsPagePnkTokenSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_pnk_token_sections';
+  info: {
+    displayName: 'BrandAssetsPagePNKTokenSection';
+    pluralName: 'brand-assets-page-pnk-token-sections';
+    singularName: 'brand-assets-page-pnk-token-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    imageDownload: Schema.Attribute.Component<
+      'brand-assets-page.image-download',
+      false
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-pnk-token-section.brand-assets-page-pnk-token-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subtitle: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiBrandAssetsPageStyledImagesSectionBrandAssetsPageStyledImagesSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'brand_assets_page_styled_images_sections';
+  info: {
+    displayName: 'BrandAssetsPageStyledImagesSection';
+    pluralName: 'brand-assets-page-styled-images-sections';
+    singularName: 'brand-assets-page-styled-images-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    header: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::brand-assets-page-styled-images-section.brand-assets-page-styled-images-section'
+    > &
+      Schema.Attribute.Private;
+    productMockupsHeader: Schema.Attribute.String;
+    productMockupsImageDownloads: Schema.Attribute.Component<
+      'brand-assets-page.image-download',
+      true
+    >;
+    productMockupsSubtitle: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    wallpapersHeader: Schema.Attribute.String;
+    wallpapersImageDownloads: Schema.Attribute.Component<
+      'brand-assets-page.image-download',
+      true
+    >;
+    wallpapersSubtitle: Schema.Attribute.String;
+  };
+}
+
 export interface ApiCommunityPageHeroCommunityPageHero
   extends Struct.SingleTypeSchema {
   collectionName: 'community_page_heroes';
@@ -2527,6 +2801,14 @@ declare module '@strapi/strapi' {
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
       'api::annual-report.annual-report': ApiAnnualReportAnnualReport;
+      'api::brand-assets-page-hero.brand-assets-page-hero': ApiBrandAssetsPageHeroBrandAssetsPageHero;
+      'api::brand-assets-page-kleros-badges-section.brand-assets-page-kleros-badges-section': ApiBrandAssetsPageKlerosBadgesSectionBrandAssetsPageKlerosBadgesSection;
+      'api::brand-assets-page-kleros-colors-section.brand-assets-page-kleros-colors-section': ApiBrandAssetsPageKlerosColorsSectionBrandAssetsPageKlerosColorsSection;
+      'api::brand-assets-page-kleros-fonts-section.brand-assets-page-kleros-fonts-section': ApiBrandAssetsPageKlerosFontsSectionBrandAssetsPageKlerosFontsSection;
+      'api::brand-assets-page-kleros-logo-section.brand-assets-page-kleros-logo-section': ApiBrandAssetsPageKlerosLogoSectionBrandAssetsPageKlerosLogoSection;
+      'api::brand-assets-page-logos-package-section.brand-assets-page-logos-package-section': ApiBrandAssetsPageLogosPackageSectionBrandAssetsPageLogosPackageSection;
+      'api::brand-assets-page-pnk-token-section.brand-assets-page-pnk-token-section': ApiBrandAssetsPagePnkTokenSectionBrandAssetsPagePnkTokenSection;
+      'api::brand-assets-page-styled-images-section.brand-assets-page-styled-images-section': ApiBrandAssetsPageStyledImagesSectionBrandAssetsPageStyledImagesSection;
       'api::community-page-hero.community-page-hero': ApiCommunityPageHeroCommunityPageHero;
       'api::community.community': ApiCommunityCommunity;
       'api::cooperative-page-hero.cooperative-page-hero': ApiCooperativePageHeroCooperativePageHero;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added multiple content types for Brand Assets Page in CMS backend
	- Introduced new sections for Hero, Kleros Badges, Colors, Fonts, Logo, Logos Package, PNK Token, and Styled Images
	- Created components for color cards and image downloads

- **Content Type Additions**
	- Brand Assets Page Hero
	- Kleros Badges Section
	- Kleros Colors Section
	- Kleros Fonts Section
	- Kleros Logo Section
	- Logos Package Section
	- PNK Token Section
	- Styled Images Section

- **Components Added**
	- Color Card component
	- Image Download component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->