### PR TITLE
Fix(cms): add missing home page types

### DIFF
--- a/cms-backend/src/api/home-case-studies-section/content-types/home-case-studies-section/schema.json
+++ b/cms-backend/src/api/home-case-studies-section/content-types/home-case-studies-section/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "home-case-studies-section",
     "pluralName": "home-case-studies-sections",
-    "displayName": "HomeCaseStudiesSection"
+    "displayName": "HomeCaseStudiesSection",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -18,6 +19,11 @@
     "subtitle": {
       "type": "text",
       "required": false
+    },
+    "cards": {
+      "type": "component",
+      "repeatable": true,
+      "component": "content.link-card"
     }
   }
 }

--- a/cms-backend/src/api/home-use-cases-section/content-types/home-use-cases-section/schema.json
+++ b/cms-backend/src/api/home-use-cases-section/content-types/home-use-cases-section/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "singleType",
+  "collectionName": "home_use_cases_sections",
+  "info": {
+    "singularName": "home-use-cases-section",
+    "pluralName": "home-use-cases-sections",
+    "displayName": "HomeUseCasesSection",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "arrowLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "content.button-link"
+    }
+  }
+}

--- a/cms-backend/src/api/home-use-cases-section/controllers/home-use-cases-section.ts
+++ b/cms-backend/src/api/home-use-cases-section/controllers/home-use-cases-section.ts
@@ -1,0 +1,7 @@
+/**
+ * home-use-cases-section controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::home-use-cases-section.home-use-cases-section');

--- a/cms-backend/src/api/home-use-cases-section/routes/home-use-cases-section.ts
+++ b/cms-backend/src/api/home-use-cases-section/routes/home-use-cases-section.ts
@@ -1,0 +1,7 @@
+/**
+ * home-use-cases-section router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::home-use-cases-section.home-use-cases-section');

--- a/cms-backend/src/api/home-use-cases-section/services/home-use-cases-section.ts
+++ b/cms-backend/src/api/home-use-cases-section/services/home-use-cases-section.ts
@@ -1,0 +1,7 @@
+/**
+ * home-use-cases-section service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::home-use-cases-section.home-use-cases-section');

--- a/cms-backend/src/components/content/section.json
+++ b/cms-backend/src/components/content/section.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_content_sections",
   "info": {
-    "displayName": "section"
+    "displayName": "section",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -14,6 +15,16 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::link.link"
+    },
+    "background": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/cms-backend/types/generated/components.d.ts
+++ b/cms-backend/types/generated/components.d.ts
@@ -92,9 +92,13 @@ export interface ContentNavlink extends Struct.ComponentSchema {
 export interface ContentSection extends Struct.ComponentSchema {
   collectionName: 'components_content_sections';
   info: {
+    description: '';
     displayName: 'section';
   };
   attributes: {
+    background: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    >;
     links: Schema.Attribute.Relation<'oneToMany', 'api::link.link'>;
     title: Schema.Attribute.String &
       Schema.Attribute.Required &

--- a/cms-backend/types/generated/contentTypes.d.ts
+++ b/cms-backend/types/generated/contentTypes.d.ts
@@ -1533,6 +1533,7 @@ export interface ApiHomeCaseStudiesSectionHomeCaseStudiesSection
   extends Struct.SingleTypeSchema {
   collectionName: 'home_case_studies_sections';
   info: {
+    description: '';
     displayName: 'HomeCaseStudiesSection';
     pluralName: 'home-case-studies-sections';
     singularName: 'home-case-studies-section';
@@ -1541,6 +1542,7 @@ export interface ApiHomeCaseStudiesSectionHomeCaseStudiesSection
     draftAndPublish: true;
   };
   attributes: {
+    cards: Schema.Attribute.Component<'content.link-card', true>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1727,6 +1729,37 @@ export interface ApiHomeStartEarningSectionHomeStartEarningSection
     publishedAt: Schema.Attribute.DateTime;
     subtitle: Schema.Attribute.String;
     title: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiHomeUseCasesSectionHomeUseCasesSection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'home_use_cases_sections';
+  info: {
+    description: '';
+    displayName: 'HomeUseCasesSection';
+    pluralName: 'home-use-cases-sections';
+    singularName: 'home-use-cases-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    arrowLink: Schema.Attribute.Component<'content.button-link', false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::home-use-cases-section.home-use-cases-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    title: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -3141,6 +3174,7 @@ declare module '@strapi/strapi' {
       'api::home-learn-posts-section.home-learn-posts-section': ApiHomeLearnPostsSectionHomeLearnPostsSection;
       'api::home-page-hero.home-page-hero': ApiHomePageHeroHomePageHero;
       'api::home-start-earning-section.home-start-earning-section': ApiHomeStartEarningSectionHomeStartEarningSection;
+      'api::home-use-cases-section.home-use-cases-section': ApiHomeUseCasesSectionHomeUseCasesSection;
       'api::kleros-logo.kleros-logo': ApiKlerosLogoKlerosLogo;
       'api::lemon-cash-section.lemon-cash-section': ApiLemonCashSectionLemonCashSection;
       'api::link.link': ApiLinkLink;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added "home-case-studies-section" with card support
	- Introduced "home-use-cases-section" content type with title and arrow link
	- Enhanced "section" component with background media support

- **Chores**
	- Created corresponding controllers, routes, and services for new content types in CMS backend

<!-- end of auto-generated comment: release notes by coderabbit.ai -->